### PR TITLE
CF-50 implemented a template for user authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "amazon-cognito-identity-js": "^6.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
@@ -39,6 +40,55 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+      "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.296.0.tgz",
+      "integrity": "sha512-s0wIac64rrMEo2ioUxP9IarGiiCGmelCspNcoNTPSjGl25QqjhyfQqTeGgS58qJ4fHoQb07qra39930xp1IzJg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5200,6 +5250,18 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/amazon-cognito-identity-js": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.1.2.tgz",
+      "integrity": "sha512-Ptutf9SLvKEM1Kr2kTPUvu/9THjQ0Si1l80iZYcS8NqScAAiDg8WjOOhQeJPcQDXt3Vym91luZ6zNW/3ErjEdQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "buffer": "4.9.2",
+        "fast-base64-decode": "^1.0.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "js-cookie": "^2.2.1"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5750,6 +5812,25 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5919,6 +6000,16 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -8233,6 +8324,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9284,6 +9380,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -9704,6 +9819,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -11759,6 +11883,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -12373,6 +12502,44 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -16270,9 +16437,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -16369,6 +16536,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -17491,6 +17663,56 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+      "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+      "requires": {
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.296.0.tgz",
+      "integrity": "sha512-s0wIac64rrMEo2ioUxP9IarGiiCGmelCspNcoNTPSjGl25QqjhyfQqTeGgS58qJ4fHoQb07qra39930xp1IzJg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "requires": {
+        "tslib": "^2.3.1"
       }
     },
     "@babel/code-frame": {
@@ -21068,6 +21290,18 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "requires": {}
     },
+    "amazon-cognito-identity-js": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.1.2.tgz",
+      "integrity": "sha512-Ptutf9SLvKEM1Kr2kTPUvu/9THjQ0Si1l80iZYcS8NqScAAiDg8WjOOhQeJPcQDXt3Vym91luZ6zNW/3ErjEdQ==",
+      "requires": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "buffer": "4.9.2",
+        "fast-base64-decode": "^1.0.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "js-cookie": "^2.2.1"
+      }
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -21471,6 +21705,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -21604,6 +21843,16 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -23290,6 +23539,11 @@
         }
       }
     },
+    "fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -24052,6 +24306,11 @@
         "harmony-reflect": "^1.4.6"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -24326,6 +24585,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -25829,6 +26097,11 @@
         }
       }
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -26287,6 +26560,35 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "node-forge": {
@@ -28927,9 +29229,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -28997,6 +29299,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "amazon-cognito-identity-js": "^6.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/src/App.js
+++ b/src/App.js
@@ -1,19 +1,20 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from "react-router-dom";
 
-import Discover from './pages/Discover';
-import Following from './pages/Following';
-import MessageCenter from './pages/MessageCenter';
-import Setting from './pages/Setting';
-import UserProfile from './pages/UserProfile';
-import NotFound from './pages/NotFound';
-import CreatePost from './pages/CreatePost';
+import Discover from "./pages/Discover";
+import Following from "./pages/Following";
+import MessageCenter from "./pages/MessageCenter";
+import Setting from "./pages/Setting";
+import UserProfile from "./pages/UserProfile";
+import NotFound from "./pages/NotFound";
+import CreatePost from "./pages/CreatePost";
+import TempLogin from "./pages/TempLogin";
 
-import { createTheme } from '@mui/material/styles';
-import { ThemeProvider } from '@emotion/react';
+import { createTheme } from "@mui/material/styles";
+import { ThemeProvider } from "@emotion/react";
 
 const appFont = createTheme({
   typography: {
-    fontFamily: ['Andale Mono'].join(','),
+    fontFamily: ["Andale Mono"].join(","),
   },
 });
 
@@ -29,6 +30,7 @@ function App() {
           <Route path="/setting" element={<Setting />} />
           <Route path="/userProfile" element={<UserProfile />} />
           <Route path="/createPost" element={<CreatePost />} />
+          <Route path="/login" element={<TempLogin />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </ThemeProvider>

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,0 +1,118 @@
+import React, { useState, useEffect, useContext } from "react";
+
+import * as cognito from "../lib/cognito";
+
+export const AuthStatus = {
+  Loading: 0,
+  SignedIn: 1,
+  SignedOut: 2,
+};
+
+const defaultState = {
+  sessionInfo: {},
+  authStatus: AuthStatus.Loading,
+};
+
+export const AuthContext = React.createContext(defaultState);
+
+export const AuthIsSignedIn = ({ children }) => {
+  const { authStatus } = useContext(AuthContext);
+
+  return <>{authStatus === AuthStatus.SignedIn ? children : null}</>;
+};
+
+export const AuthIsNotSignedIn = ({ children }) => {
+  const { authStatus } = useContext(AuthContext);
+
+  return <>{authStatus === AuthStatus.SignedOut ? children : null}</>;
+};
+
+const AuthProvider = ({ children }) => {
+  const [authStatus, setAuthStatus] = useState(AuthStatus.Loading);
+  const [sessionInfo, setSessionInfo] = useState({});
+  const [attrInfo, setAttrInfo] = useState([]);
+
+  useEffect(() => {
+    async function getSessionInfo() {
+      try {
+        const session = await getSession();
+        setSessionInfo({
+          idToken: session.idToken.jwtToken,
+          refreshToken: session.refreshToken.token,
+        });
+        window.localStorage.setItem("idToken", `${session.idToken.jwtToken}`);
+        window.localStorage.setItem(
+          "refreshToken",
+          `${session.refreshToken.token}`
+        );
+        const attr = await getAttributes();
+        setAttrInfo(attr);
+        setAuthStatus(AuthStatus.SignedIn);
+      } catch (err) {
+        setAuthStatus(AuthStatus.SignedOut);
+      }
+    }
+    getSessionInfo();
+  }, [setAuthStatus, authStatus]);
+
+  if (authStatus === AuthStatus.Loading) {
+    return null;
+  }
+
+  async function signInWithEmail(username, password) {
+    try {
+      await cognito.signInWithEmail(username, password);
+      setAuthStatus(AuthStatus.SignedIn);
+    } catch (err) {
+      setAuthStatus(AuthStatus.SignedOut);
+      throw err;
+    }
+  }
+
+  function signOut() {
+    cognito.signOut();
+    setAuthStatus(AuthStatus.SignedOut);
+  }
+
+  async function getSession() {
+    try {
+      const session = await cognito.getSession();
+      return session;
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  async function getAttributes() {
+    try {
+      const attr = await cognito.getAttributes();
+      return attr;
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  async function setAttribute(attr) {
+    try {
+      const res = await cognito.setAttribute(attr);
+      return res;
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  const state = {
+    authStatus,
+    sessionInfo,
+    attrInfo,
+    signInWithEmail,
+    signOut,
+    getSession,
+    getAttributes,
+    setAttribute,
+  };
+
+  return <AuthContext.Provider value={state}>{children}</AuthContext.Provider>;
+};
+
+export default AuthProvider;

--- a/src/lib/cognito.js
+++ b/src/lib/cognito.js
@@ -1,0 +1,110 @@
+import {
+  AuthenticationDetails,
+  CognitoUser,
+  CognitoUserAttribute,
+  CognitoUserPool,
+} from "amazon-cognito-identity-js";
+
+import { USER_POOL_ID, USER_POOL_CLIENT_ID } from "../keys";
+
+const poolData = {
+  UserPoolId: `${USER_POOL_ID}`,
+  ClientId: `${USER_POOL_CLIENT_ID}`,
+};
+
+const userPool = new CognitoUserPool(poolData);
+
+let currentUser = userPool.getCurrentUser();
+
+export function getCurrentUser() {
+  return currentUser;
+}
+
+function getCognitoUser(username) {
+  const userData = {
+    Username: username,
+    Pool: userPool,
+  };
+  const cognitoUser = new CognitoUser(userData);
+
+  return cognitoUser;
+}
+
+export async function getSession() {
+  if (!currentUser) {
+    currentUser = userPool.getCurrentUser();
+  }
+
+  return new Promise(function (resolve, reject) {
+    currentUser.getSession(function (err, session) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(session);
+      }
+    });
+  }).catch((err) => {
+    throw err;
+  });
+}
+
+export async function signInWithEmail(username, password) {
+  return new Promise(function (resolve, reject) {
+    const authenticationData = {
+      Username: username,
+      Password: password,
+    };
+    const authenticationDetails = new AuthenticationDetails(authenticationData);
+
+    currentUser = getCognitoUser(username);
+
+    currentUser.authenticateUser(authenticationDetails, {
+      onSuccess: function (res) {
+        resolve(res);
+      },
+      onFailure: function (err) {
+        reject(err);
+      },
+    });
+  }).catch((err) => {
+    throw err;
+  });
+}
+
+export function signOut() {
+  if (currentUser) {
+    currentUser.signOut();
+  }
+}
+
+export async function getAttributes() {
+  return new Promise(function (resolve, reject) {
+    currentUser.getUserAttributes(function (err, attributes) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(attributes);
+      }
+    });
+  }).catch((err) => {
+    throw err;
+  });
+}
+
+export async function setAttribute(attribute) {
+  return new Promise(function (resolve, reject) {
+    const attributeList = [];
+    const res = new CognitoUserAttribute(attribute);
+    attributeList.push(res);
+
+    currentUser.updateAttributes(attributeList, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  }).catch((err) => {
+    throw err;
+  });
+}

--- a/src/pages/Discover.js
+++ b/src/pages/Discover.js
@@ -1,23 +1,24 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 
-import { GET_FEED_URL, API_KEY } from '../keys';
+import { GET_FEED_URL, API_KEY } from "../keys";
 
-import Header from '../components/UI/Header/Header';
-import PageWrapper from '../components/UI/PageWrapper/PageWrapper';
-import FeedCard from '../components/UI/FeedCard/FeedCard';
-import WrapperCard from '../components/UI/WrapperCard/WrapperCard';
-import { CardStyled } from '../components/UI/FeedCard/FeedCardStyles';
+import Header from "../components/UI/Header/Header";
+import PageWrapper from "../components/UI/PageWrapper/PageWrapper";
+import FeedCard from "../components/UI/FeedCard/FeedCard";
+import WrapperCard from "../components/UI/WrapperCard/WrapperCard";
+import { CardStyled } from "../components/UI/FeedCard/FeedCardStyles";
 
-import CardHeader from '@mui/material/CardHeader';
-import CardContent from '@mui/material/CardContent';
-import Skeleton from '@mui/material/Skeleton';
+import CardHeader from "@mui/material/CardHeader";
+import CardContent from "@mui/material/CardContent";
+import Skeleton from "@mui/material/Skeleton";
+import TextField from "@mui/material/TextField";
 
 const Discover = () => {
   const [feedList, setFeedList] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const getFeedListParams = { region: 'seattle', userId: 'testUser' };
+  const getFeedListParams = { region: "seattle", userId: "testUser" };
 
   useEffect(() => {
     const getFeedListHandler = async () => {
@@ -26,12 +27,12 @@ const Discover = () => {
       const response = await fetch(
         GET_FEED_URL + new URLSearchParams(getFeedListParams).toString(),
         {
-          method: 'GET',
-          headers: { 'x-api-key': API_KEY },
+          method: "GET",
+          headers: { "x-api-key": API_KEY },
         }
       );
       if (!response.ok) {
-        throw new Error('Something went wrong, please refresh the page!');
+        throw new Error("Something went wrong, please refresh the page!");
       }
       const data = await response.json();
       setFeedList(data.feedList);
@@ -95,7 +96,7 @@ const Discover = () => {
     pageContent = (
       <WrapperCard>
         <p
-          style={{ marginTop: '180px', marginLeft: '750px', fontSize: '20px' }}
+          style={{ marginTop: "180px", marginLeft: "750px", fontSize: "20px" }}
         >
           {error}
         </p>

--- a/src/pages/TempLogin.js
+++ b/src/pages/TempLogin.js
@@ -1,0 +1,23 @@
+import Signin from "./auth/Signin";
+import Signout from "./auth/Signout";
+import AuthProvider, {
+  AuthIsSignedIn,
+  AuthIsNotSignedIn,
+} from "../contexts/AuthContext";
+
+const TempLogin = () => {
+  return (
+    <>
+      <AuthProvider>
+        <AuthIsNotSignedIn>
+          <Signin />
+        </AuthIsNotSignedIn>
+        <AuthIsSignedIn>
+          <Signout />
+        </AuthIsSignedIn>
+      </AuthProvider>
+    </>
+  );
+};
+
+export default TempLogin;

--- a/src/pages/auth/Signin.js
+++ b/src/pages/auth/Signin.js
@@ -1,0 +1,40 @@
+import { useState, useContext } from "react";
+import { AuthContext } from "../../contexts/AuthContext";
+
+const Signin = () => {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const authContext = useContext(AuthContext);
+
+  const handleUsernameChange = (e) => {
+    setUsername(e.target.value);
+  };
+
+  const handlePasswordChange = (e) => {
+    setPassword(e.target.value);
+  };
+
+  return (
+    <>
+      <h3>Please sign in to use more features.</h3>
+      <label>username: </label>
+      <input type="text" onChange={handleUsernameChange} />
+      <br />
+      <label>password: </label>
+      <input type="text" onChange={handlePasswordChange} />
+      <br />
+      <button
+        onClick={async () => {
+          try {
+            await authContext.signInWithEmail(username, password);
+          } catch (err) {}
+        }}
+      >
+        Sign in
+      </button>
+    </>
+  );
+};
+
+export default Signin;

--- a/src/pages/auth/Signout.js
+++ b/src/pages/auth/Signout.js
@@ -1,0 +1,66 @@
+import { useContext, useState } from "react";
+import { AuthContext } from "../../contexts/AuthContext";
+import { API_KEY, GET_USER_FEED_LIST_URL } from "../../keys";
+import { useNavigate } from "react-router-dom";
+
+const getUserFeedListParams = { region: "seattle" };
+
+const Signout = () => {
+  const authContext = useContext(AuthContext);
+  const [userFeedList, setUserFeedList] = useState([]);
+
+  let navigate = useNavigate();
+
+  const getUserFeedListHandler = async () => {
+    const tokenSession = await authContext.getSession();
+    const token = tokenSession.idToken.jwtToken;
+    console.log("idToken: ----", token);
+    const response = await fetch(
+      GET_USER_FEED_LIST_URL +
+        new URLSearchParams(getUserFeedListParams).toString(),
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "x-api-key": API_KEY,
+        },
+      }
+    );
+
+    const data = await response.json();
+    console.log("Data: ", data);
+    setUserFeedList(data.feedList);
+  };
+
+  return (
+    <>
+      <h3>
+        You are signed in now. To go back to this page after navigation, please
+        mannualy enter "/login" to the URL.
+      </h3>
+      <button
+        onClick={async () => {
+          try {
+            await authContext.signOut();
+          } catch (err) {}
+        }}
+      >
+        Sign out
+      </button>
+      <br />
+      <button onClick={getUserFeedListHandler}>
+        Send request to "/getUserFeedList" (token and data logged to console)
+      </button>
+      <br />
+      <button
+        onClick={() => {
+          navigate("/discover");
+        }}
+      >
+        Go to Discover page
+      </button>
+    </>
+  );
+};
+
+export default Signout;


### PR DESCRIPTION
This pull request is for https://petparentpro.atlassian.net/browse/CF-50?atlOrigin=eyJpIjoiNjY5YzM4MGU1ZGZhNDI3YWExYTk3ODVmZjVkYjIyYmIiLCJwIjoiaiJ9

The template for user authentication has been added using react context and amazon-cognito-identity-js. Please do "**npm install**" before running the project. The full authentication cycle can be tested by manually going to "/login" path. A test user has been internally created for this test. 

Please review. Thanks!